### PR TITLE
Remove choice around SoundCloud URL parameters

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -58,3 +58,6 @@ sass:
 plugins:
 - jekyll-autoprefixer
 - jekyll-github-metadata
+
+constants:
+  soundcloud_url_format: https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/$TRACKID$&color=%23281d1c&inverse=false&auto_play=false&show_user=true

--- a/_data/events.yml
+++ b/_data/events.yml
@@ -3,20 +3,18 @@
   number: 3
   speaker: Macky McCleary, former Administrator of the RI Division of Public Utilities, current Partner at Innogy Consulting, and a Senior Fellow at The Policy Lab
   description: Listen in to hear about the impact of the changing energy grid on the climate and your everyday life.
-  soundcloud: https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/678516996&color=%23281d1c&inverse=false&auto_play=false&show_user=true
+  soundcloud_track_id: 678516996
 
 - title: How do you raise a three-year old? (Emily Oster)
   date: 2019-08-23
   number: 2
   speaker: Emily Oster, Professor of Economics and International and Public Affairs, Brown University
   description: The author of <i><a href="https://www.penguinrandomhouse.com/books/572658/cribsheet-by-emily-oster/9780525559252/">Cribsheet</a></i> and <i><a href="https://www.penguinrandomhouse.com/books/310896/expecting-better-by-emily-oster/9780143125709/">Expecting Better</a></i> joins us for a conversation about how data can help us become better, more relaxed parents.
-  soundcloud: https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/653157113&color=%23281d1c&inverse=false&auto_play=false&show_user=true
+  soundcloud_track_id: 653157113
 
 - title: How can government data be leveraged for public good? (Amy O'Hara)
   date: 2019-08-07
   number: 1
   speaker: Amy O'Hara, Research Professor, Georgetown Massive Data Institute
   description: A conversation about the messy intersection of data governance, evidence building, and privacy in pursuit of leveraging our administrative data for the public good.
-  soundcloud: https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/653154167&color=%23281d1c&inverse=false&auto_play=false&show_user=true
-  
-
+  soundcloud_track_id: 653154167

--- a/_includes/events.html
+++ b/_includes/events.html
@@ -9,8 +9,8 @@
                 {% if event.description %}
                   <p>{{ event.description }}</p>
                 {% endif %}
-                {% if event.soundcloud %}
-                  <iframe width="100%" height="20" scrolling="no" frameborder="no" allow="autoplay" src="{{ event.soundcloud }}"></iframe>
+                {% if event.soundcloud_track_id %}
+                  <iframe width="100%" height="20" scrolling="no" frameborder="no" allow="autoplay" src="{{ site.constants.soundcloud_url_format | replace: '$TRACKID$', event.soundcloud_track_id }}"></iframe>
                 {% endif %}
               </div>
             {%- endfor -%}


### PR DESCRIPTION
Long term issue fix for issue arising from PR #3 and fixed in #4.

The specific choices for query parameters in sound cloud links vastly affect
the functionality of the page, indeed, sometimes breaking it. This removes
the choice of the user being able to set the full URL in the _data and instead
only prompts them to provide a track_id